### PR TITLE
UNIX support, reload perm, all console commands, more... 

### DIFF
--- a/src/com/codisimus/plugins/phatloots/PhatLoot.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLoot.java
@@ -173,7 +173,7 @@ public class PhatLoot {
 
             //Give money to the Player if there is money to give
             if (amount > 0 && !player.getGameMode().equals(GameMode.CREATIVE)
-                    && PhatLoots.hasPermission(player, "moneyfrommobs")) {
+                    && player.hasPermission("phatloots.moneyfrommobs")) {
                 String money = Econ.reward(player.getName(), amount);
                 player.sendMessage(PhatLootsMessages.mobDroppedMoney.replace("<amount>", money));
             }
@@ -640,7 +640,7 @@ public class PhatLoot {
     }
 
     /**
-     * removes the PhatLootChest for the given Block and links it to this PhatLoot
+     * Removes the PhatLootChest for the given Block and links it to this PhatLoot
      *
      * @param block The given Block
      */

--- a/src/com/codisimus/plugins/phatloots/PhatLoots.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLoots.java
@@ -7,11 +7,11 @@ import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
 import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.PluginManager;
@@ -42,7 +42,6 @@ public class PhatLoots extends JavaPlugin {
     static HashSet<String> restricted = new HashSet<String>();
     static JavaPlugin plugin;
     static String dataFolder;
-    private static Permission permission;
     private static HashMap<String, PhatLoot> phatLoots = new HashMap<String, PhatLoot>();
 
     /**
@@ -83,17 +82,17 @@ public class PhatLoots extends JavaPlugin {
 
         dataFolder = dir.getPath();
 
-        dir = new File(dataFolder + "/PhatLoots");
+        dir = new File(dataFolder + File.separator + "PhatLoots");
         if (!dir.isDirectory()) {
             dir.mkdir();
         }
 
-        dir = new File(dataFolder + "/Item Descriptions");
+        dir = new File(dataFolder + File.separator + "Item Descriptions");
         if (!dir.isDirectory()) {
             dir.mkdir();
         }
 
-        dir = new File(dataFolder + "/Books");
+        dir = new File(dataFolder + File.separator + "Books");
         if (!dir.isDirectory()) {
             dir.mkdir();
         }
@@ -102,13 +101,7 @@ public class PhatLoots extends JavaPlugin {
         loadData();
         PhatLootsConfig.load();
 
-        /* Link Permissions/Economy */
-        RegisteredServiceProvider<Permission> permissionProvider =
-                getServer().getServicesManager().getRegistration(Permission.class);
-        if (permissionProvider != null) {
-            permission = permissionProvider.getProvider();
-        }
-
+        /* Link Economy */
         RegisteredServiceProvider<Economy> economyProvider =
                 getServer().getServicesManager().getRegistration(Economy.class);
         if (economyProvider != null) {
@@ -136,17 +129,6 @@ public class PhatLoots extends JavaPlugin {
     }
 
     /**
-     * Returns boolean value of whether the given player has the specific permission
-     *
-     * @param player The Player who is being checked for permission
-     * @param type The String of the permission, ex. admin
-     * @return true if the given player has the specific permission
-     */
-    public static boolean hasPermission(Player player, String type) {
-        return permission.has(player, "phatloots." + type);
-    }
-
-    /**
      * Returns true if the given player is allowed to loot the specified PhatLoot
      *
      * @param player The Player who is being checked for permission
@@ -155,10 +137,10 @@ public class PhatLoots extends JavaPlugin {
      */
     public static boolean canLoot(Player player, PhatLoot phatLoot) {
         if (!useRestricted || restricted.contains(phatLoot.name)) {
-            if (hasPermission(player, "loot.*")) { //Check for loot all permission
+            if (player.hasPermission("phatloots.loot.*")) { //Check for loot all permission
                 return true;
             } else {
-                return hasPermission(player, "loot." + phatLoot.name); //Check if the Player has the specific loot permission
+                return player.hasPermission("phatloots.loot." + phatLoot.name); //Check if the Player has the specific loot permission
             }
         } else {
             return true;
@@ -170,7 +152,7 @@ public class PhatLoots extends JavaPlugin {
      */
     public static void loadData() {
         FileInputStream fis = null;
-        for (File file: new File(dataFolder + "/PhatLoots/").listFiles()) {
+        for (File file: new File(dataFolder + File.separator + "PhatLoots").listFiles()) {
             String name = file.getName();
             if (name.endsWith(".properties")) {
                 try {
@@ -252,8 +234,8 @@ public class PhatLoots extends JavaPlugin {
 
                     fis.close();
 
-                    file = new File(dataFolder + "/PhatLoots/"
-                                    + phatLoot.name + ".loottimes");
+                    file = new File(dataFolder + File.separator +"PhatLoots"
+                                    + File.separator + phatLoot.name + ".loottimes");
                     if (file.exists()) {
                         fis = new FileInputStream(file);
                         phatLoot.lootTimes.load(fis);
@@ -388,14 +370,14 @@ public class PhatLoots extends JavaPlugin {
             p.setProperty("OldChestsData", value);
 
             //Write the PhatLoot Properties to file
-            fos = new FileOutputStream(dataFolder + "/PhatLoots/"
-                                        + phatLoot.name + ".properties");
+            fos = new FileOutputStream(dataFolder + File.separator + "PhatLoots"
+                                        + File.separator + phatLoot.name + ".properties");
             p.store(fos, null);
             fos.close();
 
             //Write the PhatLoot Loot times to file
-            fos = new FileOutputStream(dataFolder + "/PhatLoots/"
-                                        + phatLoot.name + ".loottimes");
+            fos = new FileOutputStream(dataFolder + File.separator + "PhatLoots"
+            							+ File.separator + phatLoot.name + ".loottimes");
             phatLoot.lootTimes.store(fos, null);
         } catch (Exception saveFailed) {
             logger.severe("Save Failed!");
@@ -443,11 +425,11 @@ public class PhatLoots extends JavaPlugin {
      */
     public static void removePhatLoot(PhatLoot phatLoot) {
         phatLoots.remove(phatLoot.name);
-        File trash = new File(dataFolder + "/PhatLoots/"
-                                + phatLoot.name + ".properties");
+        File trash = new File(dataFolder + File.separator + "PhatLoots"
+        				+ File.separator + phatLoot.name + ".properties");
         trash.delete();
-        trash = new File(dataFolder + "/PhatLoots/"
-                        + phatLoot.name + ".lootTimes");
+        trash = new File(dataFolder + File.separator + "PhatLoots"
+        				+ File.separator + phatLoot.name + ".lootTimes");
         trash.delete();
     }
 
@@ -493,13 +475,13 @@ public class PhatLoots extends JavaPlugin {
      *
      * @param player The Player reloading the data
      */
-    public static void rl(Player player) {
+    public static void rl(CommandSender sender) {
         phatLoots.clear();
         loadData();
 
         logger.info("PhatLoots reloaded");
-        if (player != null) {
-            player.sendMessage("§5PhatLoots reloaded");
+        if (sender instanceof Player) {
+            sender.sendMessage("§5PhatLoots reloaded");
         }
     }
 

--- a/src/com/codisimus/plugins/phatloots/PhatLootsCommand.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsCommand.java
@@ -20,7 +20,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * Executes Player Commands
+ * Executes Sender Commands
  *
  * @author Codisimus
  */
@@ -60,18 +60,17 @@ public class PhatLootsCommand implements CommandExecutor {
         if (args.length > 0 && args[0].equals("give")) {
             if (args.length != 3) {
                 if (sender instanceof Player) {
-                    sendHelp((Player) sender);
+                    sendHelp(sender);
                     return true;
                 } else {
                     return false;
                 }
             }
 
-            //Cancel if the Player does not have the needed permission
+            //Cancel if the sender does not have the needed permission
             if (sender instanceof Player) {
-                Player player = (Player) sender;
-                if (!PhatLoots.hasPermission(player, "give")) {
-                    player.sendMessage(PhatLootsMessages.permission);
+                if (!sender.hasPermission("phatloots.give")) {
+                    sender.sendMessage(PhatLootsMessages.permission);
                     return true;
                 }
             }
@@ -94,24 +93,12 @@ public class PhatLootsCommand implements CommandExecutor {
             return true;
         }
 
-        //Cancel if the command is not from a Player
-        if (!(sender instanceof Player)) {
-            if (args.length == 1 && args[0].equals("rl")) {
-                PhatLoots.rl();
-            } else if (args.length == 2 && args[0].equals("reset")) {
-                reset(null, args[1]);
-            }
-            return false;
-        }
-
-        Player player = (Player) sender;
-
-        //Display the help page if the Player did not add any arguments
+        //Display the help page if the sender did not add any arguments
         if (args.length == 0) {
-            sendHelp(player);
+            sendHelp(sender);
             return true;
         }
-
+        
         Action action;
 
         try {
@@ -120,107 +107,108 @@ public class PhatLootsCommand implements CommandExecutor {
             //Cancel if the first argument is not a valid PhatLoot
             PhatLoot phatLoot = PhatLoots.getPhatLoot(args[0]);
             if (phatLoot == null) {
-                player.sendMessage("§4PhatLoot §6" + args[0] + "§4 does not exist");
+                sender.sendMessage("§4PhatLoot §6" + args[0] + "§4 does not exist");
                 return true;
             }
 
-            //Cancel if the Player does not have the needed permission
-            if (!PhatLoots.hasPermission(player, "commandloot")
-                    || !(PhatLoots.canLoot(player, phatLoot))) {
-                player.sendMessage(PhatLootsMessages.permission);
-                return true;
+            //Cancel if the sender does not have the needed permission
+            if (sender instanceof Player) {
+            	if (!sender.hasPermission("phatloots.commandloot")
+            			|| !(PhatLoots.canLoot((Player)sender, phatLoot))) {
+            		sender.sendMessage(PhatLootsMessages.permission);
+            		return true;
+            	}
+            	Inventory inventory = PhatLoots.server.createInventory((Player)sender, 54, phatLoot.name);
+            	
+            	//Open the Inventory
+            	((Player)sender).openInventory(inventory);
+            	
+            	phatLoot.getLoot((Player)sender, new PhatLootChest(((Player)sender).getLocation().getBlock()), inventory);
             }
-
-            Inventory inventory = PhatLoots.server.createInventory(player, 54, phatLoot.name);
-
-            //Open the Inventory
-            player.openInventory(inventory);
-
-            phatLoot.getLoot(player, new PhatLootChest(player.getLocation().getBlock()), inventory);
             return true;
         }
 
         //Execute the correct command
         switch (action) {
         case MAKE:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
-                return true;
-            }
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
+        		return true;
+        	}
 
             if (args.length == 2) {
-                make(player, args[1]);
+                make(sender, args[1]);
             } else {
-                sendCreateHelp(player);
+                sendCreateHelp(sender);
             }
 
             return true;
 
         case DELETE:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
                 return true;
-            }
-
+        	}
+        	
             if (args.length == 2) {
                 PhatLoot delete = PhatLoots.getPhatLoot(args[1]);
 
                 if (delete == null) {
-                    player.sendMessage("§4PhatLoot §6" + args[1] + "§4 does not exist");
+                    sender.sendMessage("§4PhatLoot §6" + args[1] + "§4 does not exist");
                 } else {
                     PhatLoots.removePhatLoot(delete);
-                    player.sendMessage("§5PhatLoot §6" + delete.name + "§5 was deleted!");
+                    sender.sendMessage("§5PhatLoot §6" + delete.name + "§5 was deleted!");
                 }
             } else {
-                sendCreateHelp(player);
+                sendCreateHelp(sender);
             }
 
             return true;
 
         case LINK:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
-                return true;
-            }
-
+        	//Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
+        		return true;
+        	}
+        	
             if (args.length == 2) {
-                link(player, args[1]);
+                link(sender, args[1]);
             } else {
-                sendCreateHelp(player);
+                sendCreateHelp(sender);
             }
 
             return true;
 
         case UNLINK:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
-                return true;
-            }
-
+        	//Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
+        		return true;
+        	}
             switch (args.length) {
             case 1:
-                unlink(player, null);
+                unlink(sender, null);
                 break;
             case 2:
-                unlink(player, args[1]);
+                unlink(sender, args[1]);
                 break;
             default:
-                sendCreateHelp(player);
+                sendCreateHelp(sender);
                 break;
             }
 
             return true;
 
         case TIME:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
                 return true;
-            }
+        	}
+        	
 
             switch (args.length) {
             case 2:  //Name is not provided
@@ -228,7 +216,7 @@ public class PhatLootsCommand implements CommandExecutor {
                     break;
                 }
 
-                time(player, null, -1, -1, -1, -1);
+                time(sender, null, -1, -1, -1, -1);
                 return true;
 
             case 3: //Name is provided
@@ -236,12 +224,12 @@ public class PhatLootsCommand implements CommandExecutor {
                     break;
                 }
 
-                time(player, args[1], -1, -1, -1, -1);
+                time(sender, args[1], -1, -1, -1, -1);
                 return true;
 
             case 5: //Name is not provided
                 try {
-                    time(player, null, Integer.parseInt(args[1]), Integer.parseInt(args[2]),
+                    time(sender, null, Integer.parseInt(args[1]), Integer.parseInt(args[2]),
                             Integer.parseInt(args[3]), Integer.parseInt(args[4]));
                     return true;
                 } catch (Exception notInt) {
@@ -250,7 +238,7 @@ public class PhatLootsCommand implements CommandExecutor {
 
             case 6: //Name is provided
                 try {
-                    time(player, args[1], Integer.parseInt(args[2]), Integer.parseInt(args[3]),
+                    time(sender, args[1], Integer.parseInt(args[2]), Integer.parseInt(args[3]),
                             Integer.parseInt(args[4]), Integer.parseInt(args[5]));
                     return true;
                 } catch (Exception notInt) {
@@ -260,20 +248,20 @@ public class PhatLootsCommand implements CommandExecutor {
             default: break;
             }
 
-            sendSetupHelp(player);
+            sendSetupHelp(sender);
             return true;
 
         case GLOBAL:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
                 return true;
-            }
+        	}
 
             switch (args.length) {
             case 2: //Name is not provided
                 try {
-                    global(player, null, Boolean.parseBoolean(args[1]));
+                    global(sender, null, Boolean.parseBoolean(args[1]));
                     return true;
                 } catch (Exception notBool) {
                     break;
@@ -281,7 +269,7 @@ public class PhatLootsCommand implements CommandExecutor {
 
             case 3: //Name is provided
                 try {
-                    global(player, args[1], Boolean.parseBoolean(args[2]));
+                    global(sender, args[1], Boolean.parseBoolean(args[2]));
                     return true;
                 } catch (Exception notBool) {
                     break;
@@ -290,20 +278,20 @@ public class PhatLootsCommand implements CommandExecutor {
             default: break;
             }
 
-            sendSetupHelp(player);
+            sendSetupHelp(sender);
             return true;
 
         case ROUND:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+        		sender.sendMessage(PhatLootsMessages.permission);
                 return true;
-            }
+        	}
 
             switch (args.length) {
             case 2: //Name is not provided
                 try {
-                    round(player, null, Boolean.parseBoolean(args[1]));
+                    round(sender, null, Boolean.parseBoolean(args[1]));
                     return true;
                 } catch (Exception notBool) {
                     break;
@@ -311,7 +299,7 @@ public class PhatLootsCommand implements CommandExecutor {
 
             case 3: //Name is provided
                 try {
-                    round(player, args[1], Boolean.parseBoolean(args[2]));
+                    round(sender, args[1], Boolean.parseBoolean(args[2]));
                     return true;
                 } catch (Exception notBool) {
                     break;
@@ -320,20 +308,20 @@ public class PhatLootsCommand implements CommandExecutor {
             default: break;
             }
 
-            sendSetupHelp(player);
+            sendSetupHelp(sender);
             return true;
 
         case REMOVE: //Fall through
         case ADD:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+            if (!sender.hasPermission("phatloots.make")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             boolean add = action.equals(Action.ADD);
             if (args.length < 2 ) {
-                sendSetupHelp(player);
+                sendSetupHelp(sender);
                 return true;
             }
 
@@ -358,7 +346,7 @@ public class PhatLootsCommand implements CommandExecutor {
                     cmd = cmd.substring(0, cmd.length() - 1);
                 }
 
-                setCommand(player, name, add, cmd);
+                setCommand(sender, name, add, cmd);
                 return true;
             }
 
@@ -367,9 +355,9 @@ public class PhatLootsCommand implements CommandExecutor {
             int id = 0; //The ID of the Loot collection (defaulted to 0 == IndividualLoots)
             int baseAmount = 1; //Stack size of the Loot item (defaulted to 1)
             int bonusAmount = 1; //Amount to possibly increase the Stack size of the Loot item (defaulted to 1)
-            double percent = 100; //The chance of recieving the Loot item (defaulted to 100)
+            double percent = 100; //The chance of receiving the Loot item (defaulted to 100)
 
-            ItemStack item = getItemStack(player, args[1]); //The Loot item
+            ItemStack item = getItemStack(sender, args[1]); //The Loot item
             if (item == null) {
                 return true;
             }
@@ -381,7 +369,7 @@ public class PhatLootsCommand implements CommandExecutor {
                 case 'p':
                     phatLoot = s;
                     if (phatLoot == null) {
-                        player.sendMessage("§4PhatLoot §6" + s + "§4 does not exist");
+                        sender.sendMessage("§4PhatLoot §6" + s + "§4 does not exist");
                         return true;
                     }
                     break;
@@ -389,7 +377,7 @@ public class PhatLootsCommand implements CommandExecutor {
                 case 'c':
                     id = getCollID(s);
                     if (id == -1) {
-                        player.sendMessage("§4Must be written as c1, c2, c3, c4, or c5.");
+                        sender.sendMessage("§4Must be written as c1, c2, c3, c4, or c5.");
                         return true;
                     }
                     break;
@@ -398,23 +386,23 @@ public class PhatLootsCommand implements CommandExecutor {
                     baseAmount = getLowerBound(s);
                     bonusAmount = getUpperBound(s);
                     if (baseAmount == -1 || bonusAmount == -1) {
-                        player.sendMessage("§6" + s + "§4 is not a valid number or range");
+                        sender.sendMessage("§6" + s + "§4 is not a valid number or range");
                         return true;
                     }
                     item.setAmount(baseAmount);
                     break;
 
                 case '%':
-                    percent = getPercent(player, s);
+                    percent = getPercent(sender, s);
                     if (percent == -1) {
-                        player.sendMessage("§6" + s + "§4 is not a percent");
+                        sender.sendMessage("§6" + s + "§4 is not a percent");
                         return true;
                     }
                     break;
                 case 'e':
                     Map<Enchantment, Integer> enchantments = getEnchantments(s);
                     if (enchantments == null) {
-                        player.sendMessage("§6" + s + "§4 is not a valid enchantment");
+                        sender.sendMessage("§6" + s + "§4 is not a valid enchantment");
                         return true;
                     }
                     item.addUnsafeEnchantments(enchantments);
@@ -423,7 +411,7 @@ public class PhatLootsCommand implements CommandExecutor {
                 case 'd':
                     short data = getData(s);
                     if (data == -1) {
-                        player.sendMessage("§6" + s + "§4 is not a valid data/durability value");
+                        sender.sendMessage("§6" + s + "§4 is not a valid data/durability value");
                         return true;
                     }
                     item.setDurability(data);
@@ -431,140 +419,146 @@ public class PhatLootsCommand implements CommandExecutor {
 
                 case 'n':
                     if (!s.matches("[a-zA-Z0-9]+")) {
-                        player.sendMessage("§4An item decription name may only contain letters and numbers");
+                        sender.sendMessage("§4An item decription name may only contain letters and numbers");
                         return true;
                     }
                     description = s;
                     break;
 
                 default:
-                    player.sendMessage("§6" + s + "§4 is not a valid parameter");
+                    sender.sendMessage("§6" + s + "§4 is not a valid parameter");
                     return true;
                 }
             }
 
-            //Contruct the Loot
+            //Construct the Loot
             Loot loot = new Loot(item, bonusAmount - baseAmount);
             loot.setProbability(percent);
             if (!loot.setName(description)) {
-                player.sendMessage("§4The Item had no lore to write to file. Perhaps use the plugin §6Lores§4 to add some");
+                sender.sendMessage("§4The Item had no lore to write to file. Perhaps use the plugin §6Lores§4 to add some");
                 return true;
                 //createDescription(player, description);
             }
 
-            setLoot(player, phatLoot, add, id, loot);
+            setLoot(sender, phatLoot, add, id, loot);
             return true;
 
         case MONEY:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             switch (args.length) {
             case 2: //Name is not provided
                 try {
-                    setMoney(player, null, args[1]);
+                    setMoney(sender, null, args[1]);
                     return true;
                 } catch (Exception notInt) {
-                    sendSetupHelp(player);
+                    sendSetupHelp(sender);
                     break;
                 }
 
             case 3: //Name is provided
                 try {
-                    setMoney(player, args[1], args[2]);
+                    setMoney(sender, args[1], args[2]);
                     return true;
                 } catch (Exception notInt) {
-                    sendSetupHelp(player);
+                    sendSetupHelp(sender);
                     break;
                 }
 
             default: break;
             }
 
-            sendSetupHelp(player);
+            sendSetupHelp(sender);
             return true;
 
         case EXP:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "make")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.make")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             switch (args.length) {
             case 2: //Name is not provided
-                setExp(player, null, args[1]);
+                setExp(sender, null, args[1]);
                 return true;
 
             case 3: //Name is provided
-                setExp(player, args[1], args[2]);
+                setExp(sender, args[1], args[2]);
                 return true;
 
             default:
-                sendSetupHelp(player);
+                sendSetupHelp(sender);
                 return true;
             }
 
         case LIST:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "list")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.list")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             if (args.length == 1) {
-                list(player);
+                list(sender);
             } else {
-                sendHelp(player);
+                sendHelp(sender);
             }
             return true;
 
         case INFO:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "info")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.info")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             switch (args.length) {
             case 1: //Name is not provided
-                info(player, null);
+                info(sender, null);
                 return true;
             case 2: //Name is provided
-                info(player, args[1]);
+                info(sender, args[1]);
                 return true;
             default:
-                sendHelp(player);
+                sendHelp(sender);
                 return true;
             }
 
         case RESET:
-            //Cancel if the Player does not have permission to use the command
-            if (!PhatLoots.hasPermission(player, "reset")) {
-                player.sendMessage(PhatLootsMessages.permission);
+            //Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.reset")) {
+                sender.sendMessage(PhatLootsMessages.permission);
                 return true;
             }
 
             switch (args.length) {
             case 1: //Name is not provided
-                reset(player, null);
+                reset(sender, null);
                 return true;
             case 2: //Name is provided
-                reset(player, args[1]);
+                reset(sender, args[1]);
                 return true;
             default:
-                sendHelp(player);
+                sendHelp(sender);
                 return true;
             }
 
         case RL:
+        	//Cancel if the sender does not have permission to use the command
+        	if (!sender.hasPermission("phatloots.rl")) {
+                sender.sendMessage(PhatLootsMessages.permission);
+                return true;
+            }
+        	
             if (args.length == 1) {
-                PhatLoots.rl(player);
+                PhatLoots.rl(sender);
             } else {
-                sendHelp(player);
+                sendHelp(sender);
             }
             return true;
 
@@ -575,29 +569,29 @@ public class PhatLootsCommand implements CommandExecutor {
                 try {
                     help = Help.valueOf(args[1].toUpperCase());
                 } catch (Exception notEnum) {
-                    sendHelp(player);
+                    sendHelp(sender);
                     return true;
                 }
 
                 switch (help) {
                 case CREATE:
-                    sendCreateHelp(player);
+                    sendCreateHelp(sender);
                     break;
                 case SETUP:
-                    sendSetupHelp(player);
+                    sendSetupHelp(sender);
                     break;
                 case LOOT:
-                    sendLootHelp(player);
+                    sendLootHelp(sender);
                     break;
                 }
             } else {
-                sendHelp(player);
+                sendHelp(sender);
             }
 
             return true;
 
         default:
-            sendHelp(player);
+            sendHelp(sender);
             return true;
         }
     }
@@ -605,29 +599,36 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Creates a new PhatLoot of the given name
      *
-     * @param player The Player creating the PhatLoot
+     * @param sender The CommandSender creating the PhatLoot
      * @param name The name of the PhatLoot being created (must not already exist)
      */
-    public static void make(Player player, String name) {
+    public static void make(CommandSender sender, String name) {
         //Cancel if the PhatLoot already exists
         if (PhatLoots.hasPhatLoot(name)) {
-            player.sendMessage("§4A PhatLoot named §6" + name + "§4 already exists.");
+            sender.sendMessage("§4A PhatLoot named §6" + name + "§4 already exists.");
             return;
         }
 
         PhatLoots.addPhatLoot(new PhatLoot(name));
-        player.sendMessage("§5PhatLoot §6" + name + "§5 Made!");
+        sender.sendMessage("§5PhatLoot §6" + name + "§5 made!");
     }
 
     /**
      * Links the target Block to the specified PhatLoot
      *
-     * @param player The Player linking the Block they are targeting
+     * @param sender The CommandSender linking the Block they are targeting
      * @param name The name of the PhatLoot the Block will be linked to
      */
-    public static void link(Player player, String name) {
-        //Cancel if the Player is not targeting a correct Block
-        Block block = player.getTargetBlock(TRANSPARENT, 10);
+    public static void link(CommandSender sender, String name) {
+    	//Cancel if the sender is console
+    	if (!(sender instanceof Player)) {
+    		sender.sendMessage("§4You cannot do this from the console!");
+    		return;
+    	}
+    	
+        //Cancel if the sender is not targeting a correct Block
+        Block block  = ((Player)sender).getTargetBlock(TRANSPARENT, 10);
+        String blockName = "Block";
         switch (block.getType()) {
         case CHEST:
             Chest chest = (Chest) block.getState();
@@ -643,48 +644,64 @@ public class PhatLootsCommand implements CommandExecutor {
             if (setUnlockable && PhatLoots.pm.isPluginEnabled("ChestLock")) {
                 Safe safe = ChestLock.findSafe(block);
                 if (safe == null) {
-                    safe = new Safe(player.getName(), block);
+                    safe = new Safe(sender.getName(), block);
                     safe.lockable = false;
                     safe.locked = false;
 
                     ChestLock.addSafe(safe);
                 }
             }
-
+            blockName = "Chest";
             break;
 
         case DISPENSER:
+        	blockName = "Dispenser";
             break;
 
         default:
-            player.sendMessage("§4You must target a Chest/Dispenser.");
+            sender.sendMessage("§4You must target a Chest/Dispenser.");
             return;
         }
 
         //Cancel if the PhatLoot with the given name does not exist
         if (!PhatLoots.hasPhatLoot(name)) {
-            player.sendMessage("§4PhatLoot §6" + name + "§4 does not exsist.");
+            sender.sendMessage("§4PhatLoot §6" + name + "§4 does not exist.");
             return;
         }
 
         PhatLoot phatLoot = PhatLoots.getPhatLoot(name);
 
         phatLoot.addChest(block);
-        player.sendMessage("§5Target Block has been linked to PhatLoot §5" + name);
+        sender.sendMessage("§5Target " + blockName + " has been linked to PhatLoot §5" + name);
         phatLoot.save();
     }
 
     /**
      * Unlinks the target Block from the specified PhatLoots
      *
-     * @param player The Player unlinking the Block they are targeting
+     * @param sender The CommandSender unlinking the Block they are targeting
      */
-    public static void unlink(Player player, String name) {
-        Block block = player.getTargetBlock(TRANSPARENT, 10);
-
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+    public static void unlink(CommandSender sender, String name) {
+    	//Cancel if the sender is console
+    	if (!(sender instanceof Player)) {
+    		sender.sendMessage("§4You cannot do this from the console!");
+    		return;
+    	}
+    	
+        Block block = ((Player)sender).getTargetBlock(TRANSPARENT, 10);
+        String blockName = "Block";
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             phatLoot.removeChest(block);
-            player.sendMessage("§5Target Block has been unlinked from PhatLoot §6" + phatLoot.name);
+            switch (block.getType()) {
+            case CHEST:
+            case ENDER_CHEST:
+            	blockName = "Chest";
+                break;
+            case DISPENSER:
+            	blockName = "Dispenser";
+                break;
+            }
+            sender.sendMessage("§5Target " + blockName + " has been unlinked from PhatLoot §6" + phatLoot.name);
             phatLoot.save();
         }
     }
@@ -692,20 +709,20 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Modifies the reset time of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param days The amount of days
      * @param hours The amount of hours
      * @param minutes The amount of minutes
      * @param seconds The amount of seconds
      */
-    public static void time(Player player, String name, int days, int hours, int minutes, int seconds) {
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+    public static void time(CommandSender sender, String name, int days, int hours, int minutes, int seconds) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             phatLoot.days = days;
             phatLoot.hours = hours;
             phatLoot.minutes = minutes;
             phatLoot.seconds = seconds;
-            player.sendMessage("§5Reset time for PhatLoot §6" + phatLoot.name
+            sender.sendMessage("§5Reset time for PhatLoot §6" + phatLoot.name
                     + "§5 has been set to §6" + days + " days, "
                     + hours + " hours, " + minutes + " minutes, and "
                     + seconds + " seconds");
@@ -717,17 +734,17 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Modifies global of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param global The new value of global
      */
-    public static void global(Player player, String name, boolean global) {
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+    public static void global(CommandSender sender, String name, boolean global) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             if (phatLoot.global != global) {
                 phatLoot.global = global;
                 phatLoot.reset(null);
 
-                player.sendMessage("§5PhatLoot §6" + phatLoot.name + "§5 has been set to §6"
+                sender.sendMessage("§5PhatLoot §6" + phatLoot.name + "§5 has been set to §6"
                         + (global ? "global" : "individual") + "§5 reset");
             }
         }
@@ -736,15 +753,15 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Modifies round of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param round The new value of round
      */
-    public static void round(Player player, String name, boolean round) {
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+    public static void round(CommandSender sender, String name, boolean round) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             phatLoot.round = round;
 
-            player.sendMessage("§5PhatLoot §6" + phatLoot.name + "§5 has been set to §6"
+            sender.sendMessage("§5PhatLoot §6" + phatLoot.name + "§5 has been set to §6"
                     + (round ? "" : "not") + "round down time");
             phatLoot.save();
         }
@@ -753,32 +770,32 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Adds/Removes a Loot to the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param add True the Loot will be added, false if it will be removed
      * @param lootID The id of the Loot, 0 for individual loots
      * @param loot The Loot that will be added/removed
      */
-    public static void setLoot(Player player, String name, boolean add, int lootID, Loot loot) {
+    public static void setLoot(CommandSender sender, String name, boolean add, int lootID, Loot loot) {
         String lootDescription = loot.toInfoString();
 
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             boolean done = false;
             //Try to find the Loot
             for (Loot tempLoot: phatLoot.loots[lootID]) {
                 if (loot.equals(tempLoot)) {
                     /*The Loot was found*/
-                    //Cancel if the Player is trying to duplicate the Loot
+                    //Cancel if the sender is trying to duplicate the Loot
                     if (!add) {
                         phatLoot.loots[lootID].remove(loot);
 
                         //Display the appropriate message
                         if (lootID == 0)  { //Individual Loot
-                            player.sendMessage("§6" + lootDescription
+                            sender.sendMessage("§6" + lootDescription
                                     + "§5 removed as Loot for PhatLoot §6"
                                     + phatLoot.name);
                         } else { //Collective Loot
-                            player.sendMessage("§6" + lootDescription
+                            sender.sendMessage("§6" + lootDescription
                                     + "§5 removed as Loot from §6coll"
                                     + lootID + "§5, §6"
                                     + phatLoot.getPercentRemaining(lootID)
@@ -787,7 +804,7 @@ public class PhatLootsCommand implements CommandExecutor {
 
                         phatLoot.save();
                     } else {
-                        player.sendMessage("§6" + lootDescription
+                        sender.sendMessage("§6" + lootDescription
                                 + "§4 is already Loot for PhatLoot §6"
                                 + phatLoot.name);
                     }
@@ -805,11 +822,11 @@ public class PhatLootsCommand implements CommandExecutor {
 
                     //Display the appropriate message
                     if (lootID == 0) { //Individual Loot
-                        player.sendMessage("§6" + lootDescription
+                        sender.sendMessage("§6" + lootDescription
                                 + "§5 added as Loot for PhatLoot §6"
                                 + phatLoot.name);
                     } else { //Collective Loot
-                        player.sendMessage("§6" + lootDescription
+                        sender.sendMessage("§6" + lootDescription
                                 + "§5 added as Loot to §6coll"
                                 + lootID + "§5, §6"
                                 + phatLoot.getPercentRemaining(lootID)
@@ -818,7 +835,7 @@ public class PhatLootsCommand implements CommandExecutor {
 
                     phatLoot.save();
                 } else {
-                    player.sendMessage("§6" + lootDescription
+                    sender.sendMessage("§6" + lootDescription
                             + "§4 was not found as a Loot for PhatLoot §6"
                             + phatLoot.name);
                 }
@@ -829,22 +846,23 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Sets the money range of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param amount The String of the range of the amount
      */
-    public static void setMoney(Player player, String name, String amount) {
+    public static void setMoney(CommandSender sender, String name, String amount) {
         int lower = getLowerBound(amount);
         int upper = getUpperBound(amount);
         if (lower == -1 || upper == -1) {
-            player.sendMessage("§6" + amount + " §4is not a valid number or range");
+            sender.sendMessage("§6" + amount + " §4is not a valid number or range");
+            return;
         }
 
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             phatLoot.moneyLower = lower;
             phatLoot.moneyUpper = upper;
 
-            player.sendMessage("§5Money for PhatLoot §6"
+            sender.sendMessage("§5Money for PhatLoot §6"
                     + phatLoot.name + "§5 set to "
                     + (lower == upper
                        ? "§6"
@@ -857,22 +875,23 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Sets the experience range of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param amount The String of the range of the amount
      */
-    public static void setExp(Player player, String name, String amount) {
+    public static void setExp(CommandSender sender, String name, String amount) {
         int lower = getLowerBound(amount);
         int upper = getUpperBound(amount);
         if (lower == -1 || upper == -1) {
-            player.sendMessage("§6" + amount + " §4is not a valid number or range");
+            sender.sendMessage("§6" + amount + " §4is not a valid number or range");
+            return;
         }
 
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             phatLoot.expLower = lower;
             phatLoot.expUpper = upper;
 
-            player.sendMessage("§5Experience for PhatLoot §6"
+            sender.sendMessage("§5Experience for PhatLoot §6"
                     + phatLoot.name + "§5 set to "
                     + (lower == upper
                        ? "§6"
@@ -885,31 +904,31 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Manages commands of the specified PhatLoot
      *
-     * @param player The Player modifying the PhatLoot
+     * @param sender The CommandSender modifying the PhatLoot
      * @param name The name of the PhatLoot to be modified or null to indicate all linked PhatLoots
      * @param add True if the command is to be added
      * @param cmd The command to be added/removed
      */
-    public static void setCommand(Player player, String name, boolean add, String cmd) {
+    public static void setCommand(CommandSender sender, String name, boolean add, String cmd) {
         if (cmd.startsWith("/")) {
             cmd = cmd.substring(1);
         }
 
-        for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+        for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
             boolean done = false;
             //Try to find the cmd
             for (String string: phatLoot.commands) {
                 if (cmd.equals(string)) {
                     /*The Loot was found*/
-                    //Cancel if the Player is trying to duplicate the cmd
+                    //Cancel if the sender is trying to duplicate the cmd
                     if (!add) {
                         phatLoot.commands.remove(cmd);
-                        player.sendMessage("§6" + cmd
+                        sender.sendMessage("§6" + cmd
                                 + "§5 removed as a command for PhatLoot §6"
                                 + phatLoot.name);
                         phatLoot.save();
                     } else {
-                        player.sendMessage("§6" + cmd
+                        sender.sendMessage("§6" + cmd
                                 + "§4 is already a command for PhatLoot §6"
                                 + phatLoot.name);
                     }
@@ -924,12 +943,12 @@ public class PhatLootsCommand implements CommandExecutor {
                 //Cancel if the cmd is not present
                 if (add) {
                     phatLoot.commands.add(cmd);
-                    player.sendMessage("§6" + cmd
+                    sender.sendMessage("§6" + cmd
                             + "§5 added as a command for PhatLoot §6"
                             + phatLoot.name);
                     phatLoot.save();
                 } else {
-                    player.sendMessage("§6" + cmd
+                    sender.sendMessage("§6" + cmd
                             + "§4 was not found as a command for PhatLoot §6"
                             + phatLoot.name);
                 }
@@ -940,9 +959,9 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Displays a list of current PhatLoot
      *
-     * @param player The Player requesting the list
+     * @param sender The CommandSender requesting the list
      */
-    public static void list(Player player) {
+    public static void list(CommandSender sender) {
         String list = "§5Current PhatLoots: §6";
 
         //Concat each PhatLoot
@@ -950,18 +969,18 @@ public class PhatLootsCommand implements CommandExecutor {
             list += phatLoot.name + ", ";
         }
 
-        player.sendMessage(list.substring(0, list.length() - 2));
+        sender.sendMessage(list.substring(0, list.length() - 2));
     }
 
     /**
      * Displays the info of the specified PhatLoot
      * If a name is not provided, a list of PhatLoots linked to the target Block is displayed
      *
-     * @param player The Player requesting the info
+     * @param sender The CommandSender requesting the info
      * @param name The name of the PhatLoot
      */
-    public static void info(Player player, String name) {
-        LinkedList<PhatLoot> phatLoots = getPhatLoots(player, name);
+    public static void info(CommandSender sender, String name) {
+        LinkedList<PhatLoot> phatLoots = getPhatLoots(sender, name);
         switch (phatLoots.size()) {
         case 0:
             break;
@@ -969,30 +988,30 @@ public class PhatLootsCommand implements CommandExecutor {
         case 1: //Display information for the one PhatLoot
             PhatLoot phatLoot = phatLoots.getFirst();
 
-            player.sendMessage("§2Name:§b " + phatLoot.name
+            sender.sendMessage("§2Name:§b " + phatLoot.name
                     + " §2Global Reset:§b " + phatLoot.global
                     + " §2Round Down:§b " + phatLoot.round);
-            player.sendMessage("§2Reset Time:§b " + phatLoot.days
+            sender.sendMessage("§2Reset Time:§b " + phatLoot.days
                     + " days, " + phatLoot.hours + " hours, "
                     + phatLoot.minutes + " minutes, and "
                     + phatLoot.seconds + " seconds.");
-            player.sendMessage("§2Money§b: " + phatLoot.moneyLower + "-"
+            sender.sendMessage("§2Money§b: " + phatLoot.moneyLower + "-"
                     + phatLoot.moneyUpper + " §2Experience§b: "
                     + phatLoot.expLower + "-" + phatLoot.expUpper);
-            player.sendMessage("§2# of collective loots:§b "
+            sender.sendMessage("§2# of collective loots:§b "
                     + phatLoot.numberCollectiveLoots);
 
             //Display Individual Loots if not empty
             String loots = phatLoot.getLoots(0);
             if (!loots.isEmpty()) {
-                player.sendMessage("§2IndividualLoots§b: " + loots);
+                sender.sendMessage("§2IndividualLoots§b: " + loots);
             }
 
             //Display each Collective Loots that is not empty
             for (int i = 1; i <= 5; i++) {
                 loots = phatLoot.getLoots(i);
                 if (!loots.isEmpty()) {
-                    player.sendMessage("§2Coll" + i + "§b: " + loots);
+                    sender.sendMessage("§2Coll" + i + "§b: " + loots);
                 }
             }
 
@@ -1006,7 +1025,7 @@ public class PhatLootsCommand implements CommandExecutor {
                 list += pl.name + ", ";
             }
 
-            player.sendMessage(list.substring(0, list.length() - 2));
+            sender.sendMessage(list.substring(0, list.length() - 2));
             break;
         }
     }
@@ -1015,10 +1034,10 @@ public class PhatLootsCommand implements CommandExecutor {
      * Reset the use times of the specified PhatLoot/PhatLootChest
      * If a name is not provided, the target PhatLootChest is reset
      *
-     * @param player The Player reseting the PhatLootChests
+     * @param sender The CommandSender reseting the PhatLootChests
      * @param name The name of the PhatLoot
      */
-    public static void reset(Player player, String name) {
+    public static void reset(CommandSender sender, String name) {
         //Reset the target Button if a name was not provided
         if (name != null) {
             //Reset all Buttons in every PhatLoot if the name provided is 'all'
@@ -1027,8 +1046,8 @@ public class PhatLootsCommand implements CommandExecutor {
                     phatLoots.reset(null);
                 }
 
-                if (player != null) {
-                    player.sendMessage("§5All Chests in each PhatLoot have been reset.");
+                if (sender != null) {
+                    sender.sendMessage("§5All Chests in each PhatLoot have been reset.");
                 }
                 return;
             }
@@ -1038,8 +1057,8 @@ public class PhatLootsCommand implements CommandExecutor {
 
             //Cancel if the PhatLoot does not exist
             if (!PhatLoots.hasPhatLoot(name)) {
-                if (player != null) {
-                    player.sendMessage("§4PhatLoot §6" + name + "§4 does not exsist.");
+                if (sender != null) {
+                    sender.sendMessage("§4PhatLoot §6" + name + "§4 does not exsist.");
                 }
                 return;
             }
@@ -1047,16 +1066,31 @@ public class PhatLootsCommand implements CommandExecutor {
             //Reset all Chests linked to the PhatLoot
             phatLoot.reset(null);
 
-            if (player != null) {
-                player.sendMessage("§5All Chests in PhatLoot §6"
+            if (sender != null) {
+                sender.sendMessage("§5All Chests in PhatLoot §6"
                                     + name + "§5 have been reset.");
             }
-        } else if (player != null) {
-            Block block = player.getTargetBlock(TRANSPARENT, 10);
-
-            for (PhatLoot phatLoot: getPhatLoots(player, name)) {
+        } else if (sender != null) {
+        	//Cancel is the sender is console
+        	if (!(sender instanceof Player)) {
+        		sender.sendMessage("§4You cannot do this from the console!");
+        		return;
+        	}
+        	
+            Block block = ((Player)sender).getTargetBlock(TRANSPARENT, 10);
+            String blockName = "Block";
+            for (PhatLoot phatLoot: getPhatLoots(sender, name)) {
                 phatLoot.reset(block);
-                player.sendMessage("§5Target Block has been reset.");
+                switch (block.getType()) {
+                case CHEST:
+                case ENDER_CHEST:
+                	blockName = "Chest";
+                    break;
+                case DISPENSER:
+                	blockName = "Dispenser";
+                    break;
+                }
+                sender.sendMessage("§5Target "+ blockName + " has been reset.");
             }
         }
     }
@@ -1064,120 +1098,131 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Displays the PhatLoots Help Page to the given Player
      *
-     * @param player The Player needing help
+     * @param sender The CommandSender needing help
      */
-    private static void sendHelp(Player player) {
-        player.sendMessage("§e     PhatLoots Help Page:");
-        player.sendMessage("§2/"+command+" <Name>§b Loot a virtual Chest for the given PhatLoot");
-        player.sendMessage("§2/"+command+" list§b List all PhatLoots");
-        player.sendMessage("§2/"+command+" info [Name]§b List info of PhatLoot");
-        player.sendMessage("§2/"+command+" give <Name> <Player>§b Force Player to open a PhatLoot");
-        player.sendMessage("§2/"+command+" reset§b Reset looted times for target Block");
-        player.sendMessage("§2/"+command+" reset <Name>§b Reset looted times for PhatLoot");
-        player.sendMessage("§2/"+command+" reset all§b Reset looted times for all PhatLoots");
-        player.sendMessage("§2/"+command+" help create§b Display PhatLoots Create Help Page");
-        player.sendMessage("§2/"+command+" help setup§b Display PhatLoots Setup Help Page");
-        player.sendMessage("§2/"+command+" help loot§b Display PhatLoots Manage Loot Help Page");
-        player.sendMessage("§2/"+command+" rl§b Reload PhatLoots Plugin");
+    private static void sendHelp(CommandSender sender) {
+        sender.sendMessage("§e     PhatLoots Help Page:");
+        sender.sendMessage("§2/"+command+" <Name>§b Loot a virtual Chest for the given PhatLoot");
+        sender.sendMessage("§2/"+command+" list§b List all PhatLoots");
+        sender.sendMessage("§2/"+command+" info [Name]§b List info of PhatLoot");
+        sender.sendMessage("§2/"+command+" give <Name> <Player>§b Force Sender to open a PhatLoot");
+        sender.sendMessage("§2/"+command+" reset§b Reset looted times for target Block");
+        sender.sendMessage("§2/"+command+" reset <Name>§b Reset looted times for PhatLoot");
+        sender.sendMessage("§2/"+command+" reset all§b Reset looted times for all PhatLoots");
+        sender.sendMessage("§2/"+command+" help create§b Display PhatLoots Create Help Page");
+        sender.sendMessage("§2/"+command+" help setup§b Display PhatLoots Setup Help Page");
+        sender.sendMessage("§2/"+command+" help loot§b Display PhatLoots Manage Loot Help Page");
+        sender.sendMessage("§2/"+command+" rl§b Reload PhatLoots Plugin");
     }
 
     /**
      * Displays the PhatLoots Create Help Page to the given Player
      *
-     * @param player The Player needing help
+     * @param sender The CommandSender needing help
      */
-    private static void sendCreateHelp(Player player) {
-        player.sendMessage("§e     PhatLoots Create Help Page:");
-        player.sendMessage("§7If Name is not specified then all PhatLoots linked to the target Block will be affected");
-        player.sendMessage("§2/"+command+" make <Name>§b Create PhatLoot with given name");
-        player.sendMessage("§2/"+command+" delete <Name>§b Delete PhatLoot");
-        player.sendMessage("§2/"+command+" link <Name>§b Link target Chest/Dispenser with PhatLoot");
-        player.sendMessage("§2/"+command+" unlink [Name]§b Unlink target Block from PhatLoot");
+    private static void sendCreateHelp(CommandSender sender) {
+        sender.sendMessage("§e     PhatLoots Create Help Page:");
+        sender.sendMessage("§7If Name is not specified then all PhatLoots linked to the target Block will be affected");
+        sender.sendMessage("§2/"+command+" make <Name>§b Create PhatLoot with given name");
+        sender.sendMessage("§2/"+command+" delete <Name>§b Delete PhatLoot");
+        sender.sendMessage("§2/"+command+" link <Name>§b Link target Chest/Dispenser with PhatLoot");
+        sender.sendMessage("§2/"+command+" unlink [Name]§b Unlink target Block from PhatLoot");
     }
 
     /**
      * Displays the PhatLoots Setup Help Page to the given Player
      *
-     * @param player The Player needing help
+     * @param sender The CommandSender needing help
      */
-    private static void sendSetupHelp(Player player) {
-        player.sendMessage("§e     PhatLoots Setup Help Page:");
-        player.sendMessage("§7If Name is not specified then all PhatLoots linked to the target Block will be affected");
-        player.sendMessage("§6Amount may be a number §4(100)§6 or range §4(100-500)");
-        player.sendMessage("§2/"+command+" time [Name] <Days> <Hrs> <Mins> <Secs>§b Set cooldown time for PhatLoot");
-        player.sendMessage("§2/"+command+" time [Name] never§b Set PhatLoot to only be lootable once per chest");
-        player.sendMessage("§2/"+command+" global [Name] true§b Set PhatLoot to a global cooldown");
-        player.sendMessage("§2/"+command+" global [Name] false§b Set PhatLoot to an individual cooldown");
-        player.sendMessage("§2/"+command+" round [Name] <true|false>§b Set if cooldown times should round down (ex. Daily/Hourly loots)");
-        player.sendMessage("§2/"+command+" money [Name] <Amount>§b Set money range to be looted");
-        player.sendMessage("§2/"+command+" exp [Name] <Amount>§b Set experience to be gained");
-        player.sendMessage("§2/"+command+" add cmd [Name] /<Command>§b Add a Command that will be executed upon looting");
-        player.sendMessage("§2/"+command+" remove cmd [Name] /<Command>§b Remove a Command that will be executed upon looting");
+    private static void sendSetupHelp(CommandSender sender) {
+        sender.sendMessage("§e     PhatLoots Setup Help Page:");
+        sender.sendMessage("§7If Name is not specified then all PhatLoots linked to the target Block will be affected");
+        sender.sendMessage("§6Amount may be a number §4(100)§6 or range §4(100-500)");
+        sender.sendMessage("§2/"+command+" time [Name] <Days> <Hrs> <Mins> <Secs>§b Set cooldown time for PhatLoot");
+        sender.sendMessage("§2/"+command+" time [Name] never§b Set PhatLoot to only be lootable once per chest");
+        sender.sendMessage("§2/"+command+" global [Name] true§b Set PhatLoot to a global cooldown");
+        sender.sendMessage("§2/"+command+" global [Name] false§b Set PhatLoot to an individual cooldown");
+        sender.sendMessage("§2/"+command+" round [Name] <true|false>§b Set if cooldown times should round down (ex. Daily/Hourly loots)");
+        sender.sendMessage("§2/"+command+" money [Name] <Amount>§b Set money range to be looted");
+        sender.sendMessage("§2/"+command+" exp [Name] <Amount>§b Set experience to be gained");
+        sender.sendMessage("§2/"+command+" add cmd [Name] /<Command>§b Add a Command that will be executed upon looting");
+        sender.sendMessage("§2/"+command+" remove cmd [Name] /<Command>§b Remove a Command that will be executed upon looting");
     }
 
     /**
      * Displays the PhatLoots Sign Help Page to the given Player
      *
-     * @param player The Player needing help
+     * @param sender The CommandSender needing help
      */
-    private static void sendLootHelp(Player player) {
-        player.sendMessage("§e     PhatLoots Manage Loot Help Page:");
-        player.sendMessage("§5A Parameter starts with the 1 character §2id");
-        player.sendMessage("§2p§f: §5The Name of the PhatLoot ex. §6pEpic");
-        player.sendMessage("§bIf PhatLoot is not specified then all PhatLoots linked to the target Block will be affected");
-        player.sendMessage("§2d§f: §5The data/durability value of the item ex. §6d5");
-        player.sendMessage("§2c§f: §5The id of the collective loot to specify ex. §6c1");
-        player.sendMessage("§2#§f: §5The amount of the item ex. §6#10 §5or §6#1-64 §5(default: §61§5)");
-        player.sendMessage("§2%§f: §5The chance of looting the item ex. §6%50 §5or §6%0.1 §5(default: §6100§5)");
-        player.sendMessage("§2n§f: §5The Name of the item description ex. §6nSuperSword");
-        player.sendMessage("§2e§f: §5The item enchantment ex. §6earrow_fire");
-        player.sendMessage("§bEnchantment levels can be added. ex. §6arrow_fire(2)");
-        player.sendMessage("§2/"+command+" <add|remove> <Item|ID|hand> [Parameter1] [Parameter2]...");
-        player.sendMessage("§bex. §6/"+command+" add hand #1-16 nEnderNade %32");
-        player.sendMessage("§bex. §6/"+command+" add bow earrow_fire(2) earrow_unlimited %5");
-        player.sendMessage("§bTutorial Video:");
-        player.sendMessage("§1§nwww.youtu.be/tRQuKbRTaA4");
+    private static void sendLootHelp(CommandSender sender) {
+        sender.sendMessage("§e     PhatLoots Manage Loot Help Page:");
+        sender.sendMessage("§5A Parameter starts with the 1 character §2id");
+        sender.sendMessage("§2p§f: §5The Name of the PhatLoot ex. §6pEpic");
+        sender.sendMessage("§bIf PhatLoot is not specified then all PhatLoots linked to the target Block will be affected");
+        sender.sendMessage("§2d§f: §5The data/durability value of the item ex. §6d5");
+        sender.sendMessage("§2c§f: §5The id of the collective loot to specify ex. §6c1");
+        sender.sendMessage("§2#§f: §5The amount of the item ex. §6#10 §5or §6#1-64 §5(default: §61§5)");
+        sender.sendMessage("§2%§f: §5The chance of looting the item ex. §6%50 §5or §6%0.1 §5(default: §6100§5)");
+        sender.sendMessage("§2n§f: §5The Name of the item description ex. §6nSuperSword");
+        sender.sendMessage("§2e§f: §5The item enchantment ex. §6earrow_fire");
+        sender.sendMessage("§bEnchantment levels can be added. ex. §6arrow_fire(2)");
+        sender.sendMessage("§2/"+command+" <add|remove> <Item|ID|hand> [Parameter1] [Parameter2]...");
+        sender.sendMessage("§bex. §6/"+command+" add hand #1-16 nEnderNade %32");
+        sender.sendMessage("§bex. §6/"+command+" add bow earrow_fire(2) earrow_unlimited %5");
+        sender.sendMessage("§bTutorial Video:");
+        sender.sendMessage("§1§nwww.youtu.be/tRQuKbRTaA4");
     }
 
     /**
-     * Returns the a LinkedLsit of PhatLoots
+     * Returns the a LinkedList of PhatLoots
      * If a name is provided then only the PhatLoot with the given name will be in the List
      * If no name is provided then each PhatLoot that is linked to the target Block will be in the List
      *
-     * @param player The Player targeting a Block
+     * @param sender The CommandSender targeting a Block
      * @param name The name of the PhatLoot to be found
-     * @return The a LinkedLsit of PhatLoots
+     * @return The a LinkedList of PhatLoots
      */
-    public static LinkedList<PhatLoot> getPhatLoots(Player player, String name) {
+    public static LinkedList<PhatLoot> getPhatLoots(CommandSender sender, String name) {
         LinkedList<PhatLoot> phatLoots = new LinkedList<PhatLoot>();
 
         if (name != null) {
             //Find the PhatLoot using the given name
             PhatLoot phatLoot = PhatLoots.getPhatLoot(name);
 
-            //Inform the Player if the PhatLoot does not exist
+            //Inform the sender if the PhatLoot does not exist
             if (phatLoot != null ) {
                 phatLoots.add(phatLoot);
             } else {
-                player.sendMessage("§4PhatLoot §6" + name + "§4 does not exist.");
+                sender.sendMessage("§4PhatLoot §6" + name + "§4 does not exist.");
             }
         } else {
-            //Cancel if the Player is not targeting a correct Block
-            Block block = player.getTargetBlock(TRANSPARENT, 10);
+        	//Cancel is the sender is console
+        	if (!(sender instanceof Player)) {
+        		sender.sendMessage("§4You cannot do this from the console!");
+        		return phatLoots;
+        	}
+        	
+            //Cancel if the sender is not targeting a correct Block
+        	Block block = ((Player)sender).getTargetBlock(TRANSPARENT, 10);
+        	String blockName = "Block";
             switch (block.getType()) {
-            case DISPENSER: break;
-            case ENDER_CHEST: break;
-            case CHEST: break;
+            case CHEST:
+            case ENDER_CHEST:
+            	blockName = "Chest";
+                break;
+            case DISPENSER:
+            	blockName = "Dispenser";
+                break;
             default:
-                player.sendMessage("§4You must target a Chest/Dispenser.");
+                sender.sendMessage("§4You must target a Chest/Dispenser.");
                 return phatLoots;
             }
 
             phatLoots = PhatLoots.getPhatLoots(block);
 
-            //Inform the Player if the Block is not linked to any PhatLoots
+            //Inform the sender if the Block is not linked to any PhatLoots
             if (phatLoots.isEmpty()) {
-                player.sendMessage("§4Target Block is not linked to a PhatLoot");
+                sender.sendMessage("§4Target " + blockName + " is not linked to a PhatLoot");
             }
         }
 
@@ -1187,7 +1232,7 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves an int value from the given string that starts with coll
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the id
      */
     public static int getCollID(String string) {
@@ -1207,7 +1252,7 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves an int value from the given string
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the amount
      */
     public static int getLowerBound(String string) {
@@ -1225,7 +1270,7 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves an int value from the given string
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the amount
      */
     public static int getUpperBound(String string) {
@@ -1243,12 +1288,14 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves an int value from the given string
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the item
      */
-    public static ItemStack getItemStack(Player player, String string) {
+    public static ItemStack getItemStack(CommandSender sender, String string) {
         if (string.equals("hand")) {
-            return player.getItemInHand().clone();
+        	if (sender instanceof Player) {
+        		return ((Player)sender).getItemInHand().clone();
+        	}
         }
 
         Material material = null;
@@ -1262,8 +1309,8 @@ public class PhatLootsCommand implements CommandExecutor {
 
         //Verify that the item is valid
         if (material == null) {
-            if (player != null) {
-                player.sendMessage("§6" + string + "§4 is not a valid item id");
+            if (sender != null) {
+                sender.sendMessage("§6" + string + "§4 is not a valid item id");
             }
             return null;
         }
@@ -1311,7 +1358,7 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves a short value from the given string
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the item
      */
     public static short getData(String string) {
@@ -1327,28 +1374,28 @@ public class PhatLootsCommand implements CommandExecutor {
     /**
      * Retrieves a double value from the given string that ends with %
      *
-     * @param player The Player that will receive error messages
+     * @param sender The CommandSender that will receive error messages
      * @param string The String that contains the percent
      */
-    public static double getPercent(Player player, String string) {
+    public static double getPercent(CommandSender sender, String string) {
         double percent;
         try {
             percent = Double.parseDouble(string);
             if (percent < 0) {
-                if (player != null) {
-                    player.sendMessage("§4The percent cannot be below 0");
+                if (sender != null) {
+                    sender.sendMessage("§4The percent cannot be below 0");
                 }
             }
             if (percent > 100) {
-                if (player != null) {
-                    player.sendMessage("§4The percent cannot be above 100");
+                if (sender != null) {
+                    sender.sendMessage("§4The percent cannot be above 100");
                 }
             } else {
                 return percent;
             }
         } catch (Exception notDouble) {
-            if (player != null) {
-                player.sendMessage("§6" + string + "§4 is not a valid number");
+            if (sender != null) {
+                sender.sendMessage("§6" + string + "§4 is not a valid number");
             }
         }
         return -1;

--- a/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
@@ -18,7 +18,7 @@ public class PhatLootsConfig {
         FileInputStream fis = null;
         try {
             //Copy the file from the jar if it is missing
-            File file = new File(PhatLoots.dataFolder + "/config.properties");
+            File file = new File(PhatLoots.dataFolder + File.separator + "config.properties");
             if (!file.exists()) {
                 PhatLoots.plugin.saveResource("config.properties", true);
             }

--- a/src/com/codisimus/plugins/phatloots/PhatLootsListener.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsListener.java
@@ -43,7 +43,7 @@ public class PhatLootsListener implements Listener {
     @EventHandler (ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onWorldLoad(WorldLoadEvent event) {
         FileInputStream fis = null;
-        for (File file: new File(PhatLoots.dataFolder + "/PhatLoots/").listFiles()) {
+        for (File file: new File(PhatLoots.dataFolder + File.separator + "PhatLoots").listFiles()) {
             String name = file.getName();
             if (name.endsWith(".properties")) {
                 try {
@@ -235,7 +235,7 @@ public class PhatLootsListener implements Listener {
         }
 
         //Return if the Player does not have permission to receive loots
-        if (!PhatLoots.hasPermission(player, "use")) {
+        if (!player.hasPermission("phatloots.use")) {
             player.sendMessage(PhatLootsMessages.permission);
             return;
         }
@@ -280,7 +280,7 @@ public class PhatLootsListener implements Listener {
         }
 
         //Cancel if the Block was not broken by an Admin
-        if (!PhatLoots.hasPermission(player, "admin")) {
+        if (!player.hasPermission("phatloots.admin")) {
             player.sendMessage(PhatLootsMessages.permission);
             event.setCancelled(true);
         }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,11 +1,12 @@
 name: PhatLoots
 main: com.codisimus.plugins.phatloots.PhatLoots
-version: 2.4.2
+version: 2.5.2
 author: Codisimus
 website: www.codisimus.com
 description: Chests with randomly generated money/items
 load: postworld
-softdepend: [Vault, EpicBossRecoded]
+depend: [Vault]
+softdepend: [EpicBossRecoded]
 commands:
   loot:
     description: Used to setup PhatLoot Chests and rewards


### PR DESCRIPTION
- IMPORTANT! Added "phatloots.rl" permission for reload.
- Made all commands accessible from the console.
- Fixed a few spelling errors (notably "exsist" -> "exist").
- Added File.separator for UNIX systems.
- Use built-in permissions.
- Depend: [Vault] until economy features can be made optional.
- Messages referencing "Block" now display either "Chest" or "Dispenser".
- Added missing return statements to setMoney() and setExp().
- Updated plugin version towards next release! :)
