### PR TITLE
Show chest name for those with invalid world

### DIFF
--- a/src/com/codisimus/plugins/phatloots/PhatLootChest.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootChest.java
@@ -77,7 +77,7 @@ public class PhatLootChest {
         World w = Bukkit.getWorld(world);
         if (w == null) { //The world is not currently loaded
             PhatLoots.logger.warning("The world '" + world + "' is not currently loaded, all linked chests in this world are being unlinked.");
-            PhatLoots.logger.warning("THIS CHEST UNLINKING IS PERMANANT IF YOU LINK/UNLINK ANY OTHER CHESTS IN THIS PHATLOOT!");
+            PhatLoots.logger.warning("THIS CHEST UNLINKING IS PERMANANT IF YOU LINK/UNLINK ANY OTHER CHESTS IN THIS PHATLOOT! (" + this.chestName + ")");
         } else {
             Block block = w.getBlockAt(x, y, z);
             switch (block.getType()) {


### PR DESCRIPTION
Will help the user to edit or remove the afflicted PhatLoot, especially if there are multiple chests in the same world. Have not tested this, but I assume chestName is not empty at this point.