### PR TITLE
Link people to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## This repo is no longer being updated. For future updates, please view: https://github.com/RednedEpic/PhatLoots.
+
 PhatLoots is a Bukkit plugin that allows a server admin to setup 'Loot Tables' that give Players Items, money, exp, etc. in the following scenarios:
 
 1.) Player opens a Chest


### PR DESCRIPTION
Adds a message to the README telling people this repo is no longer being updated and to view my fork for future updates. When you find time, would you mind linking to the new plugin page (https://www.spigotmc.org/resources/68925/) or this repo on the Bukkit pages and any other documentation.

For now, since my fork only supports 1.13+, I am currently referring people to the page on your site as a 'legacy' version which works on those older, legacy versions of Minecraft.